### PR TITLE
Dependency-Check Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,11 @@
 			<artifactId>tomcat-embed-core</artifactId>
 			<version>10.1.42</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-websocket</artifactId>
+			<version>10.1.42</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>


### PR DESCRIPTION
Added and Upgraded tomcat-embed-websocket to version 10.1.42 since the version that comes with Spring Boot 3.4.5 is 10.1.40 and was flagged by dependency-check for four vulnerabilities (CVE-2025-48988, CVE-2025-49124, CVE-2025-49125, CVE-2025-46701)