### PR TITLE
Update commons-lang3 dependency for twistlock scan

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
 			<version>2.4.1</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.18.0</version>
+		</dependency>
+		<dependency>
 			<!--override for spring-security-saml2-service-provider -->
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk18on</artifactId>


### PR DESCRIPTION
Updated commons-lang3 dependency to 3.18.0 for Twistlock scan (It was bundled (Version 3.17.0) with the Velocity engine)

The dependency was identified with a known vulnerability:

commons-lang3-3.17.0.jar (pkg:maven/org.apache.commons/commons-lang3@3.17.0) : https://github.com/advisories/GHSA-j288-q9x7-2f5v